### PR TITLE
Improved logging of removal of old backups

### DIFF
--- a/ProxmoxEncryptedBackup.py
+++ b/ProxmoxEncryptedBackup.py
@@ -117,9 +117,11 @@ def encryptAndUploadFiles(recipient, sourceDirectory, sourceFiles, destinationFo
 
 def cleanupJobFiles():
 
+
     if Settings.rcloneRemoveOldBackups:
+        logging.info("Preparing to remove old backups files from:" + Settings.rcloneRemoteName)
         rclone = Rclone.Rclone()
-        rclone.removeOldFiles(Settings.rcloneRemoveThreshold,Settings.rcloneRemoteName)
+        rclone.removeOldFiles(Settings.rcloneRemoveThreshold,Settings.rcloneRemoteName, dryRun=Settings.rcloneRemoveOldBackupsDryRun)
 
     logging.info("Preparing to remove old job files from:" + Settings.jobFolder)
 
@@ -150,13 +152,13 @@ if (Settings.runOldJobId is not None or event == "job-end"):
     threadFutures = []
     threadPool = ThreadPoolExecutor(max_workers=Settings.threads)
     for index in filesToEncrypt:
-        outputFilename = re.search("vzdump-(?:qemu|lxc)-(.*)\.\w*?$", index["tarfile"])[1]
+        outputFilename = re.search("vzdump-(?:qemu|lxc)-(.*)\.\w*?$", index["targetfile"])[1]
         outputFilename += ".enc"
         threadFutures.append(
             threadPool.submit(encryptAndUploadFiles,
                               recipient=Settings.gpgRecipient,
                               sourceDirectory=pathToFiles,
-                              sourceFiles=[index["tarfile"], index["logfile"]],
+                              sourceFiles=[index["targetfile"], index["logfile"]],
                               destinationFolder=Settings.gpgOutputDirectory,
                               destinationFileName=outputFilename,
                               remoteName=Settings.rcloneRemoteName
@@ -176,3 +178,4 @@ if (Settings.runOldJobId is not None or event == "job-end"):
 
 
     cleanupJobFiles()
+

--- a/ProxmoxEncryptedBackupSettings.py
+++ b/ProxmoxEncryptedBackupSettings.py
@@ -27,4 +27,5 @@ rcloneRemoteName = "gdriveremote:"  # If root of the remote is given, it should 
 rcloneVerifyUploads = True  # If True, after the upload the local and remote files will have their hashes compared
 rcloneRemoveSourceFile = True  # If True, the upload source file will be deleted after upload. Note this is the .enc file and not the original backup files.
 rcloneRemoveOldBackups = False # If True, old remote files will be deleted
+rcloneRemoveOldBackupsDryRun = True #If True AND rcloneRemoveOldBackups is True, will only list files that would be deleted
 rcloneRemoveThreshold = "14d" # Backups older than this threshold are deleted. Format: ms|s|m|h|d|w|M|y. Example: 14d = 14 days

--- a/ProxmoxEventHandler.py
+++ b/ProxmoxEventHandler.py
@@ -23,6 +23,11 @@ class ProxmoxEventHandler:
         logging.info("Job File:" + self.jobFilePath)
         logging.debug("Raw Input parameters:" + ",".join(sys.argv))
 
+
+        if not os.path.exists(jobFolder):
+            logging.debug("Job folder does not already exist, creating it.")
+            os.makedirs(jobFolder)
+
         parser = argparse.ArgumentParser()
         parser.add_argument("phase", help="backup phase")
         parser.add_argument("attributes", help="backup attributes mode and vmid", nargs='*')
@@ -149,8 +154,8 @@ class ProxmoxEventHandler:
             dumpdir = os.environ["DUMPDIR"]
             storeid = os.environ["STOREID"]
             hostname = os.environ["HOSTNAME"]
-            # tarfile is only available in phase 'backup-end'
-            tarfile = os.environ["TARFILE"]
+            # TARGET is only available in phase 'backup-end'
+            targetfile = os.environ["TARGET"] #Contains the full path to the current VM backup file
             # logfile is only available in phase 'log-end'
             logfile = os.environ["LOGFILE"]
 
@@ -171,7 +176,7 @@ class ProxmoxEventHandler:
                 'dumpdir': dumpdir,
                 'storeid': storeid,
                 'hostname': hostname,
-                'tarfile': tarfile,
+                'targetfile': targetfile,
                 'logfile': logfile,
                 'mode': mode
             }
@@ -189,10 +194,10 @@ class ProxmoxEventHandler:
 
     '''
 
-    Returns a an array with dics with quoted tarfile and logfile elements:
+    Returns a an array with dics with quoted targetfile and logfile elements:
         [
-            {tarfile: "vzdump-qemu-107-2019_12_29-23_22_54.vma",logfile: "vzdump-qemu-107-2019_12_29-23_22_54.log"},
-            {tarfile: "vzdump-qemu-108-2019_12_29-23_22_54.vma",logfile: "vzdump-qemu-108-2019_12_29-23_22_54.log"},
+            {targetfile: "vzdump-qemu-107-2019_12_29-23_22_54.vma",logfile: "vzdump-qemu-107-2019_12_29-23_22_54.log"},
+            {targetfile: "vzdump-qemu-108-2019_12_29-23_22_54.vma",logfile: "vzdump-qemu-108-2019_12_29-23_22_54.log"},
         ]
     '''
     def getFilesFromPhase(self, phase):
@@ -200,10 +205,10 @@ class ProxmoxEventHandler:
         filePaths = []
 
         for x in self.jobinfo[phase]:
-            tarfile = self.jobinfo[phase][x]["tarfile"].split("/")[-1]
+            targetfile = self.jobinfo[phase][x]["targetfile"].split("/")[-1]
             logfile =  self.jobinfo[phase][x]["logfile"].split("/")[-1]
 
-            filePaths.append({"tarfile" : tarfile, "logfile" : logfile})
+            filePaths.append({"targetfile" : targetfile, "logfile" : logfile})
 
         logging.debug("Got " + str(len(filePaths) * 2) + " files")
 


### PR DESCRIPTION
Added option to dry-run removal of old backups
Updated to use the new env variable targetfile instead of tarfile
jobFolder is now automatically created if needed
Rclone now has hardcoded shell and home due to changes in Proxmox7